### PR TITLE
Fix deprecation of OpenSSL::Cipher::Cipher

### DIFF
--- a/lib/encrypted_cookie/encryptor.rb
+++ b/lib/encrypted_cookie/encryptor.rb
@@ -93,7 +93,7 @@ module Rack
         # Encrypts the given message with a random IV, then returns the ciphertext
         # with the IV prepended.
         def encrypt_message(message)
-          aes = OpenSSL::Cipher::Cipher.new(@cipher).encrypt
+          aes = OpenSSL::Cipher.new(@cipher).encrypt
           aes.key = @encryption_key
           iv = aes.random_iv
           aes.iv = iv
@@ -106,7 +106,7 @@ module Rack
         # OpenSSL errors and returns nil.  But this should never happen, as the
         # verify method should catch all corrupted ciphertexts.
         def decrypt_ciphertext(ciphertext)
-          aes = OpenSSL::Cipher::Cipher.new(@cipher).decrypt
+          aes = OpenSSL::Cipher.new(@cipher).decrypt
           aes.key = @encryption_key
           iv = ciphertext[0, aes.iv_len]
           aes.iv = iv

--- a/spec/encrypted_cookie_spec.rb
+++ b/spec/encrypted_cookie_spec.rb
@@ -78,7 +78,7 @@ describe EncryptedApp do
     last_response.headers['Set-Cookie'].should_not include("BAh7AA")
 
     data = unpack_cookie
-    aes = OpenSSL::Cipher::Cipher.new('aes-128-cbc').decrypt
+    aes = OpenSSL::Cipher.new('aes-128-cbc').decrypt
     aes.key = 'bar' * 10
     iv = data[0, aes.iv_len]
     crypted_text = data[aes.iv_len..-1]


### PR DESCRIPTION
Use `OpenSSL::Cipher` instead

* Fixes cvonkleist/encrypted_cookie#12