### PR TITLE
Update rack dependency to support 1.1 <= rack < 3.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,6 @@ Echoe.new('encrypted_cookie', '0.0.4') do |p|
   p.author         = "Christian von Kleist"
   p.email          = "cvonkleist at-a-place-called gmail.com"
   p.ignore_pattern = ["tmp/*", "script/*"]
-  p.runtime_dependencies = ["rack ~>1.1"]
+  p.runtime_dependencies = ["rack >=1.1 <3"]
   p.development_dependencies = ["rack-test ~>0.6.2", "sinatra ~>1.3.4", "rspec ~>2.14.1"]
 end

--- a/encrypted_cookie.gemspec
+++ b/encrypted_cookie.gemspec
@@ -22,18 +22,18 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<rack>, ["~> 1.1"])
+      s.add_runtime_dependency(%q<rack>, ["< 3", ">= 1.1"])
       s.add_development_dependency(%q<rack-test>, ["~> 0.6.2"])
       s.add_development_dependency(%q<sinatra>, ["~> 1.3.4"])
       s.add_development_dependency(%q<rspec>, ["~> 2.14.1"])
     else
-      s.add_dependency(%q<rack>, ["~> 1.1"])
+      s.add_dependency(%q<rack>, ["< 3", ">= 1.1"])
       s.add_dependency(%q<rack-test>, ["~> 0.6.2"])
       s.add_dependency(%q<sinatra>, ["~> 1.3.4"])
       s.add_dependency(%q<rspec>, ["~> 2.14.1"])
     end
   else
-    s.add_dependency(%q<rack>, ["~> 1.1"])
+    s.add_dependency(%q<rack>, ["< 3", ">= 1.1"])
     s.add_dependency(%q<rack-test>, ["~> 0.6.2"])
     s.add_dependency(%q<sinatra>, ["~> 1.3.4"])
     s.add_dependency(%q<rspec>, ["~> 2.14.1"])


### PR DESCRIPTION
rack 2.0 has been released on May 07. I don't see any related breaking changes. 