### PR TITLE
Support Rack 2.2.0+

### DIFF
--- a/encrypted_cookie.gemspec
+++ b/encrypted_cookie.gemspec
@@ -23,19 +23,19 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rack>, ["< 3", ">= 1.1"])
-      s.add_development_dependency(%q<rack-test>, ["~> 0.6.2"])
-      s.add_development_dependency(%q<sinatra>, ["~> 1.3.4"])
+      s.add_development_dependency(%q<rack-test>, [">= 0.6.2", "< 2.0"])
+      s.add_development_dependency(%q<sinatra>, [">= 1.3.4", "< 3.0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.14.1"])
     else
       s.add_dependency(%q<rack>, ["< 3", ">= 1.1"])
-      s.add_dependency(%q<rack-test>, ["~> 0.6.2"])
-      s.add_dependency(%q<sinatra>, ["~> 1.3.4"])
+      s.add_dependency(%q<rack-test>, [">= 0.6.2", "< 2.0"])
+      s.add_dependency(%q<sinatra>, [">= 1.3.4", "< 3.0"])
       s.add_dependency(%q<rspec>, ["~> 2.14.1"])
     end
   else
     s.add_dependency(%q<rack>, ["< 3", ">= 1.1"])
-    s.add_dependency(%q<rack-test>, ["~> 0.6.2"])
-    s.add_dependency(%q<sinatra>, ["~> 1.3.4"])
+    s.add_dependency(%q<rack-test>, [">= 0.6.2", "< 2.0"])
+    s.add_dependency(%q<sinatra>, [">= 1.3.4", "< 3.0"])
     s.add_dependency(%q<rspec>, ["~> 2.14.1"])
   end
 end

--- a/lib/encrypted_cookie.rb
+++ b/lib/encrypted_cookie.rb
@@ -1,11 +1,8 @@
-require 'rack/request'
-require 'rack/response'
+require 'rack'
 require 'encrypted_cookie/encryptor'
 
 module Rack
-
   module Session
-
     # Rack::Session::EncryptedCookie provides AES-256-encrypted, tamper-proof
     # cookie-based session management.
     #
@@ -32,7 +29,6 @@ module Rack
     #     for session expiry as that can be altered by the recipient. Instead,
     #     use time_to_live which is server side check.
     class EncryptedCookie
-
       EXPIRES = '_encrypted_cookie_expires_'
 
       def initialize(app, options={})

--- a/lib/encrypted_cookie/encryptor.rb
+++ b/lib/encrypted_cookie/encryptor.rb
@@ -1,5 +1,5 @@
 require 'openssl'
-require 'rack/utils'
+
 module Rack
   module Session
     class EncryptedCookie

--- a/spec/encrypted_cookie_spec.rb
+++ b/spec/encrypted_cookie_spec.rb
@@ -79,7 +79,7 @@ describe EncryptedApp do
 
     data = unpack_cookie
     aes = OpenSSL::Cipher.new('aes-128-cbc').decrypt
-    aes.key = 'bar' * 10
+    aes.key = '1234567890ABCDEF' # key must be 16 bytes
     iv = data[0, aes.iv_len]
     crypted_text = data[aes.iv_len..-1]
 


### PR DESCRIPTION
A change in Rack 2.2.0 means it's no longer safe to directly require a subset of Rack (e.g., `require "rack/response"`) because that won't trigger proper autoloading. For example, we're directly requiring "rack/response", which internally expects `::Rack::Utils` to be loaded, or to autoload. But because we've not done `require "rack"`, which sets up the autoloading, we get an uninitialized constant error (`uninitialized constant Rack::Response::Utils`). The fix is to require all of Rack.

See: rack/rack@ab41dcc#diff-10b933d2c1fdc82ceecade456c64e1c2
